### PR TITLE
Add Gamepad API driver

### DIFF
--- a/src/Hangashore/lib/drivers/gamepad.ts
+++ b/src/Hangashore/lib/drivers/gamepad.ts
@@ -1,0 +1,14 @@
+import {Observable, Disposable, Observer} from 'rx';
+
+const makeGamepadDriver = () => () => Observable.create((observer: Observer<Gamepad>) => {
+    let raf = window.requestAnimationFrame(function loop() {
+        const gamepads = navigator.getGamepads();
+        for (let i = 0; i < gamepads.length; i++) {
+            observer.onNext(gamepads[i]);
+        }
+        raf = window.requestAnimationFrame(loop);
+    });
+    return Disposable.create(() => window.cancelAnimationFrame(raf));
+});
+
+export { makeGamepadDriver };

--- a/src/Hangashore/lib/drivers/gamepad.ts
+++ b/src/Hangashore/lib/drivers/gamepad.ts
@@ -1,10 +1,17 @@
 import {Observable, Disposable, Observer} from 'rx';
 
-const makeGamepadDriver = () => () => Observable.create((observer: Observer<Gamepad>) => {
+const makeGamepadDriver = (id?: string) => () => Observable.create((observer: Observer<Gamepad>) => {
     let raf = window.requestAnimationFrame(function loop() {
         const gamepads = navigator.getGamepads();
         for (let i = 0; i < gamepads.length; i++) {
-            observer.onNext(gamepads[i]);
+            const gamepad = gamepads[i];
+            if (gamepad === undefined) {
+                continue;
+            }
+            if (id && gamepad.id !== id) {
+                continue;
+            }
+            observer.onNext(gamepad);
         }
         raf = window.requestAnimationFrame(loop);
     });


### PR DESCRIPTION
This PR adds a driver for the [Gamepad API](https://developer.mozilla.org/en-US/docs/Web/API/Gamepad_API/Using_the_Gamepad_API). My initial impression of the API is that it's particularly finicky, which is unfortunate. We may regret using this in the future.

Anyhow, basic driver usage:

```typescript
import {makeGamepadDriver} from './drivers/gamepad';
run(App, {
    gamepads: makeGamepadDriver(),
});
```

When subscribing to the gamepad stream, you get back a stream of [`Gamepad`](https://developer.mozilla.org/en-US/docs/Web/API/Gamepad) objects:

```typescript
export function Component({gamepads}: Sources): Sinks {
    gamepads.subscribe(gamepad => {
        // ???
    });
    return {
        dom: vtree$,
    };
};
```

Also note that this driver is read-only.