### PR TITLE
Add external schemas to project

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "src/Hangashore/lib/values/schemas"]
+path = src/Hangashore/lib/values/schemas
+url = https://github.com/LakeMaps/schemas.git

--- a/src/Hangashore/lib/drivers/wireless.ts
+++ b/src/Hangashore/lib/drivers/wireless.ts
@@ -7,22 +7,15 @@ export type WirelessSource = {
     rssi$: Observable<number>,
 };
 
-const protobuf = require(`protocol-buffers`);
-const messages = protobuf(`
-    ${Motion.SCHEMA}
-`);
-
 const makeWirelessDriver = (name: string) => {
     const m = WirelessLinkMicrocontroller.fromSerialPort(name);
     return (data$: Observable<Motion>) => {
-        const motion$ = data$.map(data => messages.Motion.encode({
-            surge: data.surge,
-            yaw: data.yaw,
-        }));
+        const motion$ = data$.flatMap(data =>
+            Observable.fromPromise(Motion.schema.encode(data)));
         const rssi$ = new Subject<number>();
 
         motion$.subscribe(motion => {
-            m.send(Buffer.from(motion));
+            m.send(motion);
             m.recv().then(response => rssi$.onNext(response.rssi()));
         });
         return {

--- a/src/Hangashore/lib/values/Motion.ts
+++ b/src/Hangashore/lib/values/Motion.ts
@@ -1,10 +1,7 @@
+import {Schema} from './Schema';
+
 export class Motion {
-    static readonly SCHEMA = `
-        message Motion {
-            required float surge = 1;
-            required float yaw = 2;
-        }
-    `;
+    static readonly schema = Schema.of<Motion>(`Motion`);
 
     constructor(readonly surge: number, readonly yaw: number) { /* empty */ }
 }

--- a/src/Hangashore/lib/values/Schema.ts
+++ b/src/Hangashore/lib/values/Schema.ts
@@ -1,0 +1,33 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+const protobuf = require(`protocol-buffers`);
+
+export class Schema<T> {
+    static of<X>(name: string) {
+        return new Schema<X>(path.join(__dirname, `schemas/src/`, name));
+    }
+
+    private lazySchema: Promise<any>;
+
+    constructor(filename: string) {
+        this.lazySchema = new Promise((resolve, reject) => {
+            fs.readFile(filename, (err, data) => {
+                if (err) {
+                    reject(err);
+                    return;
+                }
+
+                resolve(protobuf(data));
+            });
+        });
+    }
+
+    encode(val: T): Promise<Buffer> {
+        return this.lazySchema.then(schema => schema.encode(val));
+    }
+
+    decode(buf: Buffer): Promise<T> {
+        return this.lazySchema.then(schema => schema.decode(buf));
+    }
+}


### PR DESCRIPTION
This PR embeds the Protocol Buffer message schemas from the LakeMaps/schemas project in Hangashore. The schemas project will go on to be used in the boat as well and serves as a mechanism for reuse between the two projects.