### PR TITLE
A few bugfixes from testing

### DIFF
--- a/src/Hangashore/lib/microcontrollers/serial/SerialPort.ts
+++ b/src/Hangashore/lib/microcontrollers/serial/SerialPort.ts
@@ -6,7 +6,7 @@ type PendingReadResolve = (byte: number) => void;
 export class SerialPort {
     private readonly _port: NodeSerialPort;
 
-    private _pendingReads: PendingReadResolve[];
+    private _pendingReads: PendingReadResolve[] = [];
 
     constructor(port: string, baudRate: number = 115200) {
         this._port = new NodeSerialPort(port, {

--- a/src/Hangashore/lib/microcontrollers/serial/SerialPort.ts
+++ b/src/Hangashore/lib/microcontrollers/serial/SerialPort.ts
@@ -1,7 +1,7 @@
 import {EventEmitter} from 'events';
 import * as NodeSerialPort from 'serialport';
 
-type PendingReadResolve = (byte: number) => {};
+type PendingReadResolve = (byte: number) => void;
 
 export class SerialPort {
     private readonly _port: NodeSerialPort;

--- a/src/Hangashore/lib/values/Schema.ts
+++ b/src/Hangashore/lib/values/Schema.ts
@@ -5,12 +5,12 @@ const protobuf = require(`protocol-buffers`);
 
 export class Schema<T> {
     static of<X>(name: string) {
-        return new Schema<X>(path.join(__dirname, `schemas`, `src`, `${name}.proto`));
+        return new Schema<X>(name, path.join(__dirname, `schemas`, `src`, `${name}.proto`));
     }
 
     private lazySchema: Promise<any>;
 
-    constructor(filename: string) {
+    constructor(name: string, filename: string) {
         this.lazySchema = new Promise((resolve, reject) => {
             fs.readFile(filename, (err, data) => {
                 if (err) {
@@ -18,7 +18,7 @@ export class Schema<T> {
                     return;
                 }
 
-                resolve(protobuf(data));
+                resolve(protobuf(data)[name]);
             });
         });
     }

--- a/src/Hangashore/lib/values/Schema.ts
+++ b/src/Hangashore/lib/values/Schema.ts
@@ -5,7 +5,7 @@ const protobuf = require(`protocol-buffers`);
 
 export class Schema<T> {
     static of<X>(name: string) {
-        return new Schema<X>(path.join(__dirname, `schemas/src/`, name));
+        return new Schema<X>(path.join(__dirname, `schemas`, `src`, `${name}.proto`));
     }
 
     private lazySchema: Promise<any>;


### PR DESCRIPTION
A few bugfixes from manual testing:

- [x] Fix path to value schema files
- [x] Fix type definition of `PendingReadResolve` (it doesn't *return* a value)
- [x] Initialize the `PendingReadResolve` queue to an empty list
- [x] Index into the protobuf object properties using the message name