### PR TITLE
Resolve serial reads from existing buffer if it's nonempty

### DIFF
--- a/src/Hangashore/lib/microcontrollers/serial/SerialPort.ts
+++ b/src/Hangashore/lib/microcontrollers/serial/SerialPort.ts
@@ -35,7 +35,7 @@ export class SerialPort {
     }
 
     _parser() {
-        let data = new Buffer(0);
+        let data = Buffer.alloc(0);
         return (_: EventEmitter, buffer: Buffer) => {
             data = Buffer.concat([data, buffer]);
             while (data.length) {


### PR DESCRIPTION
This PR updates `SerialPort#recv` to resolve reads directly from an internal buffer if it has data in it. This fixes an issues where multiple reads are made (two, for example) and data arrives between them. The old implementation saw the 2nd read wait until more data arrived before it would resolve and this fixes it by consulting the buffer immediately when asked for a read and returning the next byte from it should it exist.