### PR TITLE
Serialize sending and receiving across the wireless link

### DIFF
--- a/src/Hangashore/lib/App.ts
+++ b/src/Hangashore/lib/App.ts
@@ -157,6 +157,6 @@ export function App({gamepad, wireless}: Sources): Sinks {
         new Motion(g.buttons[7].value - g.buttons[6].value, -g.axes[0]));
     return {
         dom: vtree$,
-        wireless: motion$,
+        wireless: motion$.distinctUntilChanged(),
     };
 }


### PR DESCRIPTION
Closes #25, which is indeed an issue with `send`+`recv` concurrency issues.

This PR fixes the `send`+`recv` concurrency issues by serializing calls to `send`+`recv` in the wireless driver. Where we were previously blindly calling `WirelessLinkMicrocontroller#send` and then calling `#recv`, the calls were essentially racing and the lower-levels calls to `SerialPort#recv` were occurring in who knows what "order". Not anymore! One thing at a time. We send `0x03`, wait for a response, send `0x04`, and wait for a response. Does it work now? Yes. Is this slow? You bet.