### PR TITLE
Wait for wireless send+recv to complete before sending more data

### DIFF
--- a/src/Hangashore/lib/drivers/wireless.ts
+++ b/src/Hangashore/lib/drivers/wireless.ts
@@ -15,8 +15,8 @@ const makeWirelessDriver = (name: string) => {
         const rssi$ = new Subject<number>();
 
         motion$
-            .flatMap(data => Motion.schema.encode(data))
-            .concatMap((motion) => Observable.defer(() => m.send(motion).then(_ => m.recv())))
+            .mergeMap((data) => Motion.schema.encode(data))
+            .exhaustMap((motion: Buffer) => Observable.defer(() => m.send(motion).then(_ => m.recv())))
             .subscribe((recv) => {
                 rssi$.next(recv.rssi());
             });


### PR DESCRIPTION
Closes #33

This PR updates the send rate of the wireless driver to drop outbound data received during a send ([à la my comment in that thread](https://github.com/LakeMaps/hangashore/issues/33#issuecomment-290850627)).