### PR TITLE
Set wireless baud rate to 57600 bps

### DIFF
--- a/src/Hangashore/lib/microcontrollers/serial/SerialPort.ts
+++ b/src/Hangashore/lib/microcontrollers/serial/SerialPort.ts
@@ -10,7 +10,7 @@ export class SerialPort {
 
     private _buffer = Buffer.alloc(0);
 
-    constructor(port: string, baudRate: number = 115200) {
+    constructor(port: string, baudRate: number = 57600) {
         this._port = new NodeSerialPort(port, {
             baudRate,
             parser: this._parser(),


### PR DESCRIPTION
This PR sets the default baud rate for serial ports to 57600.

Right now, this change affects only the wireless link microcontroller serial communication.