### PR TITLE
Update TypeScript dependency versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,6 @@
   },
   "devDependencies": {
     "electron-packager": "8.4.0",
-    "typescript": "^2.2.2"
+    "typescript": "^2.3.2"
   }
 }

--- a/src/Hangashore/package.json
+++ b/src/Hangashore/package.json
@@ -39,6 +39,6 @@
     "tap-list": "1.0.1",
     "tape": "4.6.3",
     "tslint": "4.4.2",
-    "typescript": "2.2.2"
+    "typescript": "2.3.2"
   }
 }


### PR DESCRIPTION
This PR upgrades the project to use TypeScript 2.3.

Refs:

- [Announcing TypeScript 2.3](https://blogs.msdn.microsoft.com/typescript/2017/04/27/announcing-typescript-2-3/)
- [TypeScript 2.3 Release Notes](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-3.html)