### PR TITLE
Update (almost all) dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "electron-packager": "electron-packager"
   },
   "devDependencies": {
-    "electron-packager": "8.4.0",
+    "electron-packager": "^8.7.0",
     "typescript": "^2.3.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,6 @@
   },
   "devDependencies": {
     "electron-packager": "8.4.0",
-    "typescript": "^2.3.2"
+    "typescript": "^2.3.3"
   }
 }

--- a/src/Hangashore/package.json
+++ b/src/Hangashore/package.json
@@ -21,7 +21,7 @@
     "openlayers": "4.1.1",
     "rxjs": "5.3.0",
     "tachyons": "4.6.2",
-    "xstream": "10.3.0"
+    "xstream": "10.8.0"
   },
   "devDependencies": {
     "@types/electron": "1.4.25",

--- a/src/Hangashore/package.json
+++ b/src/Hangashore/package.json
@@ -19,7 +19,7 @@
     "localforage": "1.5.0",
     "lodash.kebabcase": "4.1.1",
     "openlayers": "4.1.1",
-    "rxjs": "5.3.0",
+    "rxjs": "5.4.0",
     "tachyons": "4.6.2",
     "xstream": "10.8.0"
   },

--- a/src/Hangashore/package.json
+++ b/src/Hangashore/package.json
@@ -16,7 +16,7 @@
     "@cycle/rxjs-run": "7.0.0",
     "@lakemaps/schemas": "3.1.1",
     "hypercycle": "5.0.0",
-    "localforage": "1.4.3",
+    "localforage": "1.5.0",
     "lodash.kebabcase": "4.1.1",
     "openlayers": "4.0.1",
     "rxjs": "5.3.0",

--- a/src/Hangashore/package.json
+++ b/src/Hangashore/package.json
@@ -32,6 +32,6 @@
     "tap-list": "1.0.1",
     "tape": "4.6.3",
     "tslint": "4.4.2",
-    "typescript": "2.3.2"
+    "typescript": "2.3.3"
   }
 }

--- a/src/Hangashore/package.json
+++ b/src/Hangashore/package.json
@@ -11,7 +11,7 @@
     "test": "npm run build && tape test/**/*.js | tap-list"
   },
   "dependencies": {
-    "@cycle/dom": "17.1.0",
+    "@cycle/dom": "17.3.0",
     "@cycle/isolate": "2.1.0",
     "@cycle/rxjs-run": "7.0.0",
     "@lakemaps/schemas": "3.1.1",

--- a/src/Hangashore/package.json
+++ b/src/Hangashore/package.json
@@ -25,7 +25,7 @@
   },
   "devDependencies": {
     "@types/electron": "1.4.25",
-    "@types/lodash.kebabcase": "4.1.1",
+    "@types/lodash.kebabcase": "4.1.2",
     "@types/openlayers": "4.0.1",
     "@types/tape": "4.2.30",
     "electron": "1.4.4",

--- a/src/Hangashore/package.json
+++ b/src/Hangashore/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "@types/electron": "1.4.25",
     "@types/lodash.kebabcase": "4.1.2",
-    "@types/openlayers": "4.0.1",
+    "@types/openlayers": "4.1.0",
     "@types/tape": "4.2.30",
     "electron": "1.4.4",
     "tap-list": "1.0.1",

--- a/src/Hangashore/package.json
+++ b/src/Hangashore/package.json
@@ -31,7 +31,7 @@
     "electron": "1.4.4",
     "tap-list": "1.0.1",
     "tape": "4.6.3",
-    "tslint": "4.4.2",
+    "tslint": "4.5.1",
     "typescript": "2.3.3"
   }
 }

--- a/src/Hangashore/package.json
+++ b/src/Hangashore/package.json
@@ -27,7 +27,7 @@
     "@types/electron": "1.4.25",
     "@types/lodash.kebabcase": "4.1.1",
     "@types/openlayers": "4.0.1",
-    "@types/tape": "4.2.29",
+    "@types/tape": "4.2.30",
     "electron": "1.4.4",
     "tap-list": "1.0.1",
     "tape": "4.6.3",

--- a/src/Hangashore/package.json
+++ b/src/Hangashore/package.json
@@ -20,7 +20,7 @@
     "lodash.kebabcase": "4.1.1",
     "openlayers": "4.1.1",
     "rxjs": "5.4.0",
-    "tachyons": "4.6.2",
+    "tachyons": "4.7.4",
     "xstream": "10.8.0"
   },
   "devDependencies": {

--- a/src/Hangashore/package.json
+++ b/src/Hangashore/package.json
@@ -18,7 +18,7 @@
     "hypercycle": "5.0.0",
     "localforage": "1.5.0",
     "lodash.kebabcase": "4.1.1",
-    "openlayers": "4.0.1",
+    "openlayers": "4.1.1",
     "rxjs": "5.3.0",
     "tachyons": "4.6.2",
     "xstream": "10.3.0"


### PR DESCRIPTION
This PR updates almost all the the npm dependencies.

Notably I've left Electron out—I'll update Electron when I get around to it.