### PR TITLE
Remove unnecessary check for buffer size in Gps.decode

### DIFF
--- a/src/Hangashore/lib/values/Gps.ts
+++ b/src/Hangashore/lib/values/Gps.ts
@@ -4,13 +4,7 @@ import {Velocity} from './Velocity';
 const {Gps: GpsProtobuf} = require(`@lakemaps/schemas`);
 
 export class Gps {
-    static MESSAGE_SIZE = 54;
-
     static decode(buf: Buffer): Gps {
-        if (buf.length > Gps.MESSAGE_SIZE) {
-            return Gps.decode(buf.slice(0, Gps.MESSAGE_SIZE));
-        }
-
         const bytes = new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength / Uint8Array.BYTES_PER_ELEMENT);
         const obj = GpsProtobuf.deserializeBinary(bytes);
         return new Gps(


### PR DESCRIPTION
This PR removes the unnecessary check for the correct buffer size in `Gps.decode`. The check is unnecessary because the JS implementation ([google-protobuf](https://www.npmjs.com/package/google-protobuf)) of Protocol Buffers decodes extraneous bytes just fine.