### PR TITLE
Fix gamepad polling

### DIFF
--- a/src/Hangashore/lib/drivers/gamepad/driver.ts
+++ b/src/Hangashore/lib/drivers/gamepad/driver.ts
@@ -60,6 +60,9 @@ function poll(config: Config, observer: Observer<Gamepad>) {
         if (gamepad === undefined) {
             continue;
         }
+        if (gamepad === null) {
+            continue;
+        }
         if (config.id && gamepad.id !== config.id) {
             continue;
         }

--- a/src/Hangashore/lib/drivers/gamepad/driver.ts
+++ b/src/Hangashore/lib/drivers/gamepad/driver.ts
@@ -55,7 +55,7 @@ const GamepadProxy = (deadzone: DeadzoneFunction): ProxyHandler<Gamepad> => ({
 });
 
 function poll(config: Config, observer: Observer<Gamepad>) {
-    const gamepads = navigator.getGamepads();
+    const gamepads = Array.from(navigator.getGamepads());
     for (const gamepad of gamepads) {
         if (gamepad === undefined) {
             continue;


### PR DESCRIPTION
With the new Electron version (as of #68) [`Navigator#getGamepads()`][1] returns `null` to note no gamepad. This PR updates the polling function to skip `null` values as well as to convert the "array" returned by `getGamepads()` to a proper array.

  [1]:https://developer.mozilla.org/en-US/docs/Web/API/Navigator/getGamepads