### PR TITLE
TypeScript 2.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ matrix:
         - node_js: "6"
           os: osx
 before_install:
-    - npm i -g npm@5
+    - npm i -g npm@5.2.0
 install:
     - .travis/install
 script:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1701,9 +1701,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.3.4.tgz",
-      "integrity": "sha1-PTgyGCgjHkNPKHUUlZw3qCtin0I=",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.4.1.tgz",
+      "integrity": "sha1-w8yxbdqgsjFN4DHn5v7onlujRrw=",
       "dev": true
     },
     "universalify": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,6 @@
   },
   "devDependencies": {
     "electron-packager": "^8.7.1",
-    "typescript": "^2.3.4"
+    "typescript": "^2.4.1"
   }
 }

--- a/src/Hangashore/lib/components/RadioSet.ts
+++ b/src/Hangashore/lib/components/RadioSet.ts
@@ -41,7 +41,7 @@ const view = (props: RadioSetProps): VNode => {
 };
 
 export function RadioSet({dom, props$}: RadioSetSources): RadioSetSinks {
-    const initialSelected$ = props$.first()
+    const initialSelected$: Observable<string> = props$.first()
         .flatMap(({options}) => {
             const selected = options.find(({enabled, checked}) => Boolean(enabled && checked));
             return selected

--- a/src/Hangashore/package-lock.json
+++ b/src/Hangashore/package-lock.json
@@ -4857,9 +4857,9 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "typescript": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.4.1.tgz",
-      "integrity": "sha1-w8yxbdqgsjFN4DHn5v7onlujRrw=",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.4.2.tgz",
+      "integrity": "sha1-+DlfhdRZJ2BnyYiqQYN6j4KHCEQ=",
       "dev": true
     },
     "uglify-js": {

--- a/src/Hangashore/package-lock.json
+++ b/src/Hangashore/package-lock.json
@@ -4008,9 +4008,9 @@
       }
     },
     "rxjs": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.4.0.tgz",
-      "integrity": "sha1-p9sUqxV/nXqsalbmVeejhg05vyY=",
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.4.2.tgz",
+      "integrity": "sha1-KjI2/L8D31e64G/Wly/ZnlwI/Pc=",
       "requires": {
         "symbol-observable": "1.0.4"
       }

--- a/src/Hangashore/package-lock.json
+++ b/src/Hangashore/package-lock.json
@@ -4857,9 +4857,9 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "typescript": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.3.4.tgz",
-      "integrity": "sha1-PTgyGCgjHkNPKHUUlZw3qCtin0I=",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.4.1.tgz",
+      "integrity": "sha1-w8yxbdqgsjFN4DHn5v7onlujRrw=",
       "dev": true
     },
     "uglify-js": {

--- a/src/Hangashore/package-lock.json
+++ b/src/Hangashore/package-lock.json
@@ -5,13 +5,13 @@
   "requires": true,
   "dependencies": {
     "@cycle/dom": {
-      "version": "17.3.0",
-      "resolved": "https://registry.npmjs.org/@cycle/dom/-/dom-17.3.0.tgz",
-      "integrity": "sha1-mcgLdIytmKU5RvcYC6XD2UUNI/I=",
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/@cycle/dom/-/dom-18.0.0.tgz",
+      "integrity": "sha1-YFpwdR9wZY8ABVBKA6C2y7XR5o0=",
       "requires": {
         "@cycle/run": "3.1.0",
         "es6-map": "0.1.5",
-        "snabbdom": "0.6.8",
+        "snabbdom": "0.6.9",
         "snabbdom-selector": "1.2.0"
       }
     },
@@ -2463,11 +2463,11 @@
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM="
     },
     "hypercycle": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/hypercycle/-/hypercycle-5.0.0.tgz",
-      "integrity": "sha1-8/eqUT5Faj9ystifLxUKeY8jTAo=",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/hypercycle/-/hypercycle-6.0.0.tgz",
+      "integrity": "sha512-58hh9qC/pvBM6ROUMNEd7u08Pln6EcUrlIYAjQyXQ4qfLinFW94yzQk6fXtA2qltbveKZtLxSqoCmPHICmVt7g==",
       "requires": {
-        "@cycle/dom": "17.3.0",
+        "@cycle/dom": "18.0.0",
         "hyperx": "2.3.0"
       }
     },
@@ -4113,9 +4113,9 @@
       "dev": true
     },
     "snabbdom": {
-      "version": "0.6.8",
-      "resolved": "https://registry.npmjs.org/snabbdom/-/snabbdom-0.6.8.tgz",
-      "integrity": "sha1-bKf5DCA+BFDiUlocEbCtdBBBPEs="
+      "version": "0.6.9",
+      "resolved": "https://registry.npmjs.org/snabbdom/-/snabbdom-0.6.9.tgz",
+      "integrity": "sha1-ZaOS9Mgsp+jscqoNL6eXz1xzuNc="
     },
     "snabbdom-selector": {
       "version": "1.2.0",

--- a/src/Hangashore/package.json
+++ b/src/Hangashore/package.json
@@ -28,6 +28,6 @@
     "tap-list": "1.0.1",
     "tape": "4.6.3",
     "tslint": "4.5.1",
-    "typescript": "2.3.4"
+    "typescript": "2.4.1"
   }
 }

--- a/src/Hangashore/package.json
+++ b/src/Hangashore/package.json
@@ -17,7 +17,7 @@
     "@lakemaps/schemas": "3.3.0",
     "hypercycle": "5.0.0",
     "openlayers": "4.1.1",
-    "rxjs": "5.4.0",
+    "rxjs": "5.4.2",
     "tachyons": "4.7.4",
     "xstream": "10.8.0"
   },

--- a/src/Hangashore/package.json
+++ b/src/Hangashore/package.json
@@ -11,11 +11,11 @@
     "test": "npm run build && tape test/**/*.js | tap-list"
   },
   "dependencies": {
-    "@cycle/dom": "17.3.0",
+    "@cycle/dom": "18.0.0",
     "@cycle/isolate": "2.1.0",
     "@cycle/rxjs-run": "7.0.0",
     "@lakemaps/schemas": "3.3.0",
-    "hypercycle": "5.0.0",
+    "hypercycle": "6.0.0",
     "openlayers": "4.1.1",
     "rxjs": "5.4.2",
     "tachyons": "4.7.4",

--- a/src/Hangashore/package.json
+++ b/src/Hangashore/package.json
@@ -28,6 +28,6 @@
     "tap-list": "1.0.1",
     "tape": "4.6.3",
     "tslint": "4.5.1",
-    "typescript": "2.4.1"
+    "typescript": "2.4.2"
   }
 }


### PR DESCRIPTION
This PR updates the project to use TypeScript 2.4. See also: [Announcing TypeScript 2.4](https://blogs.msdn.microsoft.com/typescript/2017/06/27/announcing-typescript-2-4/).

There are (apparently) a few breaking changes in 2.4 that will require fixes. The following dependencies will also need to be updated:

- [x] RxJS
- [x] Cycle.js