### PR TITLE
TypeScript 2.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1701,9 +1701,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.4.1.tgz",
-      "integrity": "sha1-w8yxbdqgsjFN4DHn5v7onlujRrw=",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.5.2.tgz",
+      "integrity": "sha1-A4qV99m7tCCxvzW6MdTFwd0//jQ=",
       "dev": true
     },
     "universalify": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,6 @@
   },
   "devDependencies": {
     "electron-packager": "^8.7.1",
-    "typescript": "^2.4.1"
+    "typescript": "^2.5.2"
   }
 }

--- a/src/Hangashore/package-lock.json
+++ b/src/Hangashore/package-lock.json
@@ -4857,9 +4857,9 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "typescript": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.4.2.tgz",
-      "integrity": "sha1-+DlfhdRZJ2BnyYiqQYN6j4KHCEQ=",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.5.2.tgz",
+      "integrity": "sha1-A4qV99m7tCCxvzW6MdTFwd0//jQ=",
       "dev": true
     },
     "uglify-js": {

--- a/src/Hangashore/package.json
+++ b/src/Hangashore/package.json
@@ -28,6 +28,6 @@
     "tap-list": "1.0.1",
     "tape": "4.6.3",
     "tslint": "4.5.1",
-    "typescript": "2.4.2"
+    "typescript": "2.5.2"
   }
 }


### PR DESCRIPTION
This PR updates the project to use TypeScript 2.5 (`2.5.2`). See also: [Announcing TypeScript 2.5](https://blogs.msdn.microsoft.com/typescript/2017/08/31/announcing-typescript-2-5/).