### PR TITLE
Add a contributors guide

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,77 @@
+Contributor Covenant Code of Conduct
+====================================
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+Our Standards
+-------------
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+Our Responsibilities
+--------------------
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+Scope
+-----
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+Enforcement
+-----------
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at <lake.maps.nl@gmail.com>. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+Attribution
+-----------
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at [www.contributor-covenant.org](https://www.contributor-covenant.org/version/1/4/code-of-conduct/).
+
+[homepage]: https://www.contributor-covenant.org

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,39 @@
+Contributing to Hangashore
+==========================
+
+Hangashore is Lake Maps' shoreside control software. There is a core team for who this application is developed and who drive feature requests but the application is developed in the open to allow others to fork it and create derivative works.
+
+**This document describes how you can contribute to the project.**
+
+Please take a moment to review this document in order to make the contribution process easy and effective for everyone involved. Following these guidelines helps to communicate that you respect the time of the developers managing and developing this open source project. In return, we will reciprocate that respect in addressing your issue or assessing patches and/or features.
+
+Reporting issues
+----------------
+
+[You can see the list of open and closed issues on GitHub.](https://github.com/LakeMaps/hangashore/issues) [You can open a new issue by clicking "New Issue".](https://help.github.com/articles/creating-an-issue/)
+
+Issues can really be anything—bugs, enhancements, questions, tweaks, etc, are all valid issues.
+
+A few things to keep in mind:
+
+- Please try to keep issue titles terse and use [sentence case]
+- Before opening a new issue, check to see if the issue you going to open has already been filed—don't be put off by closed issues, we can reopen them if need be.
+- Please keep an issue localised to one thing—open multiple issues for multiple things
+
+Submitting Pull Requests
+------------------------
+
+[Pull requests](https://help.github.com/articles/about-pull-requests/) are the mechanism by which changes the project are proposed and accepted.
+
+A few things to keep in mind:
+
+- Please try to keep PR titles terse and use [sentence case]
+- Before opening a PR, consider opening an issue to discuss your changes
+- Please keep a PR's changeset localised to one thing—open multiple PRs for multiple things
+
+  [sentence case]:https://ux.stackexchange.com/q/28297
+
+License
+-------
+
+By contributing to this project, you agree to license your contribution under the current project license (see [`LICENSE.adoc`](LICENSE.adoc)).


### PR DESCRIPTION
Closes #36

This PR adds a contributors guide to the project in the form of a new text file named `CONTRIBUTING.md`. This file outlines the process for contributing to this project¹ and indirectly how the project is managed on GitHub.

¹ This file will be copied almost verbatim to other projects, so it should at least reflect the process that is common to all projects in this organization.

I've started the document with a note on reporting issues as well as licensing. What else should be in it?

- [x] Protocol for opening pull requests
- [x] How do we use labels?
- [x] How do we use milestones?
- What else?