### PR TITLE
Update schemas and use new TypeScript definitions

### DIFF
--- a/src/Hangashore/lib/values/BoatConfig.ts
+++ b/src/Hangashore/lib/values/BoatConfig.ts
@@ -1,15 +1,16 @@
+import {
+    BoatConfig as BoatConfigProtobuf, PidControllerGains as PidControllerGainsProtobuf, TypedMessage,
+} from '@lakemaps/schemas';
 import {PidControllerGains} from './PidControllerGains';
-
-const {
-    BoatConfig: BoatConfigProtobuf,
-    TypedMessage,
-    PidControllerGains: PidControllerGainsProtobuf,
-} = require(`@lakemaps/schemas`);
 
 export class BoatConfig {
     static decode(buf: Buffer): BoatConfig {
         const bytes = new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength / Uint8Array.BYTES_PER_ELEMENT);
         const obj = TypedMessage.deserializeBinary(bytes).getBoatConfig();
+        if (obj === null) {
+            throw new Error(`Missing BoatConfig field`);
+        }
+
         const surgeControllerGains = obj.getSurgeControllerGains();
         const surgeTimeStep = obj.getSurgeControllerDt();
         const yawControllerGains = obj.getYawControllerGains();

--- a/src/Hangashore/lib/values/ControlMode.ts
+++ b/src/Hangashore/lib/values/ControlMode.ts
@@ -1,9 +1,9 @@
-const {ControlMode: ControlModeProtobuf, TypedMessage} = require(`@lakemaps/schemas`);
+import {ControlMode as ControlModeProtobuf, TypedMessage} from '@lakemaps/schemas';
 
 export class ControlMode {
-    static readonly WAYPOINT = new ControlMode(`WAYPOINT`);
+    static readonly WAYPOINT = new ControlMode(ControlModeProtobuf.Mode.WAYPOINT);
 
-    static readonly MANUAL = new ControlMode(`MANUAL`);
+    static readonly MANUAL = new ControlMode(ControlModeProtobuf.Mode.MANUAL);
 
     static from(name: string): ControlMode {
         if ((<any> ControlMode)[name]) {
@@ -15,9 +15,9 @@ export class ControlMode {
 
     private message: any;
 
-    private constructor(private readonly name: string) {
+    private constructor(private readonly mode: ControlModeProtobuf.Mode) {
         const controlMode = new ControlModeProtobuf();
-        controlMode.setMode(ControlModeProtobuf.Mode[this.name]);
+        controlMode.setMode(mode);
         this.message = new TypedMessage();
         this.message.setType(TypedMessage.Type.CONTROL_MODE);
         this.message.setControlMode(controlMode);
@@ -28,6 +28,6 @@ export class ControlMode {
     }
 
     toString() {
-        return this.name;
+        return Object.keys(ControlModeProtobuf.Mode)[this.mode];
     }
 }

--- a/src/Hangashore/lib/values/Gps.ts
+++ b/src/Hangashore/lib/values/Gps.ts
@@ -1,12 +1,15 @@
 import {Position} from './Position';
 import {Velocity} from './Velocity';
 
-const {Gps: GpsProtobuf, TypedMessage} = require(`@lakemaps/schemas`);
+import {Gps as GpsProtobuf, TypedMessage} from '@lakemaps/schemas';
 
 export class Gps {
     static decode(buf: Buffer): Gps {
         const bytes = new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength / Uint8Array.BYTES_PER_ELEMENT);
         const obj = TypedMessage.deserializeBinary(bytes).getGps();
+        if (obj === null) {
+            throw new Error(`Missing GPS field`);
+        }
         return new Gps(
             obj.getHorizontalDilutionOfPrecision(),
             Position.fromMessage(obj.getPosition()),

--- a/src/Hangashore/lib/values/MissionInformation.ts
+++ b/src/Hangashore/lib/values/MissionInformation.ts
@@ -1,9 +1,13 @@
-const {MissionInformation: MissionInformationProtobuf, TypedMessage} = require(`@lakemaps/schemas`);
+import {MissionInformation as MissionInformationProtobuf, TypedMessage} from '@lakemaps/schemas';
 
 export class MissionInformation {
     static decode(buf: Buffer): MissionInformation {
         const bytes = new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength / Uint8Array.BYTES_PER_ELEMENT);
         const obj = TypedMessage.deserializeBinary(bytes).getMissionInformation();
+        if (obj === null) {
+            throw new Error(`Missing MissionInformation field`);
+        }
+
         return new MissionInformation(obj.getDistanceToWaypoint());
     }
 

--- a/src/Hangashore/lib/values/Motion.ts
+++ b/src/Hangashore/lib/values/Motion.ts
@@ -1,4 +1,4 @@
-const {Motion: MotionProtobuf, TypedMessage} = require(`@lakemaps/schemas`);
+import {Motion as MotionProtobuf, TypedMessage} from '@lakemaps/schemas';
 
 export class Motion {
     static decode(buf: Buffer): Motion {

--- a/src/Hangashore/lib/values/Position.ts
+++ b/src/Hangashore/lib/values/Position.ts
@@ -1,4 +1,4 @@
-const {Position: PositionProtobuf} = require(`@lakemaps/schemas`);
+import {Position as PositionProtobuf} from '@lakemaps/schemas';
 
 export class Position {
     static decode(buf: Buffer): Position {

--- a/src/Hangashore/lib/values/TypedMessage.ts
+++ b/src/Hangashore/lib/values/TypedMessage.ts
@@ -1,4 +1,4 @@
-const {TypedMessage: TypedMessageProtobuf} = require(`@lakemaps/schemas`);
+import {TypedMessage as TypedMessageProtobuf} from '@lakemaps/schemas';
 
 export class TypedMessage {
     static decode(buf: Buffer): TypedMessage {

--- a/src/Hangashore/lib/values/Velocity.ts
+++ b/src/Hangashore/lib/values/Velocity.ts
@@ -1,4 +1,4 @@
-const {Velocity: VelocityProtobuf} = require(`@lakemaps/schemas`);
+import {Velocity as VelocityProtobuf} from '@lakemaps/schemas';
 
 export class Velocity {
     static decode(buf: Buffer): Velocity {

--- a/src/Hangashore/lib/values/Waypoint.ts
+++ b/src/Hangashore/lib/values/Waypoint.ts
@@ -1,4 +1,4 @@
-const {Waypoint: WaypointProtobuf, TypedMessage} = require(`@lakemaps/schemas`);
+import {TypedMessage, Waypoint as WaypointProtobuf} from '@lakemaps/schemas';
 
 export class Waypoint {
     static decode(buf: Buffer): Waypoint {

--- a/src/Hangashore/package-lock.json
+++ b/src/Hangashore/package-lock.json
@@ -37,11 +37,11 @@
       }
     },
     "@lakemaps/schemas": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@lakemaps/schemas/-/schemas-3.3.0.tgz",
-      "integrity": "sha1-ci8+4GVVwLUI1AfiRWdcjlo0hds=",
+      "version": "3.4.18",
+      "resolved": "https://registry.npmjs.org/@lakemaps/schemas/-/schemas-3.4.18.tgz",
+      "integrity": "sha1-Ao2RXZvv+39v2ahV7jjJdLbrGLs=",
       "requires": {
-        "google-protobuf": "3.3.0"
+        "google-protobuf": "3.5.0"
       }
     },
     "@types/node": {
@@ -1637,9 +1637,9 @@
       }
     },
     "google-protobuf": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.3.0.tgz",
-      "integrity": "sha1-IcFewvvVfCNutoTS4YvK7Kl1m3c="
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.5.0.tgz",
+      "integrity": "sha1-uMxjx02DRXvYqakEUDyO+ya8ozk="
     },
     "got": {
       "version": "6.7.1",

--- a/src/Hangashore/package.json
+++ b/src/Hangashore/package.json
@@ -14,7 +14,7 @@
     "@cycle/dom": "18.0.0",
     "@cycle/isolate": "2.1.0",
     "@cycle/rxjs-run": "7.0.0",
-    "@lakemaps/schemas": "3.3.0",
+    "@lakemaps/schemas": "3.4.18",
     "hypercycle": "6.0.0",
     "openlayers": "4.5.0",
     "rxjs": "5.4.2",


### PR DESCRIPTION
Refs LakeMaps/schemas#24

This PR updates `@lakemaps/schemas` to the latest version (`3.4.x`) which now includes TypeScript definitions for all of the messages. I've switched all usages of ``require(`@lakemaps/schemas`)`` with `import` statements.