### PR TITLE
Update OpenLayers to fix potential security vulnerability in marked

### DIFF
--- a/src/Hangashore/package-lock.json
+++ b/src/Hangashore/package-lock.json
@@ -80,9 +80,9 @@
       }
     },
     "acorn": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.2.tgz",
-      "integrity": "sha512-o96FZLJBPY1lvTuJylGA9Bk3t/GKPPJG8H0ydQQl01crzwJgspa4AEIq/pVTXigmK0PHVQhiAtn8WMBLL9D2WA=="
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.2.1.tgz",
+      "integrity": "sha512-jG0u7c4Ly+3QkkW18V+NRDN+4bWHdln30NL1ZL2AvFZZmQe/BfopYCtghCKKVBUSetZ4QKcyA0pY6/4Gw8Pv8w=="
     },
     "after": {
       "version": "0.8.2",
@@ -224,9 +224,9 @@
       "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
     },
     "arraybuffer.slice": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz",
-      "integrity": "sha1-8zshWfBTKj8xB6JywMz70a0peco="
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.7.tgz",
+      "integrity": "sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog=="
     },
     "asn1": {
       "version": "0.1.11",
@@ -571,12 +571,12 @@
       }
     },
     "closure-util": {
-      "version": "1.25.0",
-      "resolved": "https://registry.npmjs.org/closure-util/-/closure-util-1.25.0.tgz",
-      "integrity": "sha512-8iE+t1iommvwcbbS2StsQXMA+pRNwKKxbPRZoHOcBJZI+F0W8wN2aTFhvX8SQIu9OKAUpT05orMEWER6FW6zBg==",
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/closure-util/-/closure-util-1.26.0.tgz",
+      "integrity": "sha512-zpWABEochWrY48soiEttuqJk/OSYscS9PcvKgHvKUefM29+R8rqx5Bp8KIZHR0Nsq1JrNgxg2VTmJ/IsqN5VOA==",
       "requires": {
-        "acorn": "5.1.2",
-        "async": "2.5.0",
+        "acorn": "5.2.1",
+        "async": "2.6.0",
         "fs-extra": "4.0.2",
         "gaze": "1.1.2",
         "get-down": "1.2.0",
@@ -595,11 +595,21 @@
       },
       "dependencies": {
         "async": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
-          "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
+          "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
           "requires": {
             "lodash": "4.17.4"
+          }
+        },
+        "fs-extra": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.2.tgz",
+          "integrity": "sha1-+RcExT0bRh+JNFKwwwfZmXZHq2s=",
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "jsonfile": "4.0.0",
+            "universalify": "0.1.1"
           }
         },
         "glob": {
@@ -613,6 +623,14 @@
             "minimatch": "3.0.4",
             "once": "1.4.0",
             "path-is-absolute": "1.0.1"
+          }
+        },
+        "jsonfile": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+          "requires": {
+            "graceful-fs": "4.1.11"
           }
         },
         "rimraf": {
@@ -968,9 +986,9 @@
         "base64id": "1.0.0",
         "cookie": "0.3.1",
         "debug": "2.6.9",
-        "engine.io-parser": "2.1.1",
+        "engine.io-parser": "2.1.2",
         "uws": "0.14.5",
-        "ws": "3.3.2"
+        "ws": "3.3.3"
       },
       "dependencies": {
         "debug": {
@@ -991,12 +1009,12 @@
         "component-emitter": "1.2.1",
         "component-inherit": "0.0.3",
         "debug": "2.6.9",
-        "engine.io-parser": "2.1.1",
+        "engine.io-parser": "2.1.2",
         "has-cors": "1.1.0",
         "indexof": "0.0.1",
         "parseqs": "0.0.5",
         "parseuri": "0.0.5",
-        "ws": "3.3.2",
+        "ws": "3.3.3",
         "xmlhttprequest-ssl": "1.5.4",
         "yeast": "0.1.2"
       },
@@ -1012,12 +1030,12 @@
       }
     },
     "engine.io-parser": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-2.1.1.tgz",
-      "integrity": "sha1-4Ps/DgRi9/WLt3waUun1p+JuRmg=",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-2.1.2.tgz",
+      "integrity": "sha512-dInLFzr80RijZ1rGpx1+56/uFoH7/7InhH3kZt+Ms6hT8tNx3NGW/WNSA/f8As1WkOfkuyb3tnRyuXGxusclMw==",
       "requires": {
         "after": "0.8.2",
-        "arraybuffer.slice": "0.0.6",
+        "arraybuffer.slice": "0.0.7",
         "base64-arraybuffer": "0.1.5",
         "blob": "0.0.4",
         "has-binary2": "1.0.2"
@@ -1391,9 +1409,9 @@
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
     },
     "fs-extra": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.2.tgz",
-      "integrity": "sha1-+RcExT0bRh+JNFKwwwfZmXZHq2s=",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
+      "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
       "requires": {
         "graceful-fs": "4.1.11",
         "jsonfile": "4.0.0",
@@ -2128,7 +2146,7 @@
         "escape-string-regexp": "1.0.5",
         "js2xmlparser": "3.0.0",
         "klaw": "2.0.0",
-        "marked": "0.3.7",
+        "marked": "0.3.9",
         "mkdirp": "0.5.1",
         "requizzle": "0.2.1",
         "strip-json-comments": "2.0.1",
@@ -2334,9 +2352,9 @@
       "dev": true
     },
     "marked": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.7.tgz",
-      "integrity": "sha512-zBEP4qO1YQp5aXHt8S5wTiOv9i2X74V/LQL0zhUNvVaklt6Ywa6lChxIvS+ibYlCGgADwKwZFhjC3+XfpsvQvQ=="
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.9.tgz",
+      "integrity": "sha512-nW5u0dxpXxHfkHzzrveY45gCbi+R4PaO4WRZYqZNl+vB0hVGeqlFn0aOg1c8AKL63TrNFn9Bm2UP4AdiZ9TPLw=="
     },
     "meow": {
       "version": "3.7.0",
@@ -2424,9 +2442,9 @@
       }
     },
     "minizlib": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.0.4.tgz",
-      "integrity": "sha512-sN4U9tIJtBRwKbwgFh9qJfrPIQ/GGTRr1MGqkgOeMTLy8/lM0FcWU//FqlnZ3Vb7gJ+Mxh3FOg1EklibdajbaQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.1.0.tgz",
+      "integrity": "sha512-4T6Ur/GctZ27nHfpt9THOdRZNgyJ9FZchYO1ceg5S8Q3DNLCKYy44nCZzgCJgcvx2UM8czmqak5BCxJMrq37lA==",
       "requires": {
         "minipass": "2.2.1"
       }
@@ -2624,19 +2642,19 @@
       }
     },
     "openlayers": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/openlayers/-/openlayers-4.5.0.tgz",
-      "integrity": "sha512-sM5Xm57+nJCS30390Dnfn0Fk/+gRUdOfo9RlinhWNQ2KGhgW9zH0s8P2aCeO2+nsIiVLrlrPKmuxiPHvawQwdQ==",
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/openlayers/-/openlayers-4.6.4.tgz",
+      "integrity": "sha512-Oru7/xniirjech7H5zkMQSUj/JUymNveiE4vAwmyjAmcoNyO4zTRD/Pp7BPfxBPuAz45vDl78H1wEQD7RGWkGg==",
       "requires": {
         "async": "2.6.0",
-        "closure-util": "1.25.0",
-        "fs-extra": "4.0.2",
+        "closure-util": "1.26.0",
+        "fs-extra": "4.0.3",
         "jsdoc": "3.5.5",
         "nomnom": "1.8.1",
         "pbf": "3.1.0",
         "pixelworks": "1.1.0",
         "rbush": "2.0.1",
-        "rollup": "0.51.8",
+        "rollup": "0.52.3",
         "rollup-plugin-cleanup": "2.0.0",
         "rollup-plugin-commonjs": "8.2.6",
         "rollup-plugin-node-resolve": "3.0.0",
@@ -2914,9 +2932,9 @@
       "dev": true
     },
     "quickselect": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-1.0.0.tgz",
-      "integrity": "sha1-AmMIGPmq5OyrJvAQP5jQYcF8WPM="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-1.0.1.tgz",
+      "integrity": "sha512-Jt30UQSzTbxf6L2bFTMabHtGtYUzQcvOY0a+s5brm8tzndV/XWifBIH9v5QKtH5gGCZ5RRDwRhdhGMDVHAEGNQ=="
     },
     "randomatic": {
       "version": "1.1.7",
@@ -2965,7 +2983,7 @@
       "resolved": "https://registry.npmjs.org/rbush/-/rbush-2.0.1.tgz",
       "integrity": "sha1-TPrKKMMGS8DudUMaG3mZDode76k=",
       "requires": {
-        "quickselect": "1.0.0"
+        "quickselect": "1.0.1"
       }
     },
     "rc": {
@@ -3178,9 +3196,9 @@
       }
     },
     "rollup": {
-      "version": "0.51.8",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.51.8.tgz",
-      "integrity": "sha512-e7FwWxqb4vhdonmwRH06nqC9wR6h1kZojK2D+lN1xjiB8FDtAKgy7o+r8fCXVzQZ1ZCdcVlls3mTq5g6u38Jew=="
+      "version": "0.52.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.52.3.tgz",
+      "integrity": "sha512-cw+vb9NqaTXlwJyb8G+Ve+uhhlVTcl1NKBkfANdeQqVcpZFilQgeNnAnNiu7MwfeXrqiKEGz+3R03a3zeFkmEQ=="
     },
     "rollup-plugin-cleanup": {
       "version": "2.0.0",
@@ -3211,11 +3229,6 @@
         "rollup-pluginutils": "2.0.1"
       },
       "dependencies": {
-        "acorn": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.2.1.tgz",
-          "integrity": "sha512-jG0u7c4Ly+3QkkW18V+NRDN+4bWHdln30NL1ZL2AvFZZmQe/BfopYCtghCKKVBUSetZ4QKcyA0pY6/4Gw8Pv8w=="
-        },
         "estree-walker": {
           "version": "0.5.1",
           "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.5.1.tgz",
@@ -3756,7 +3769,7 @@
       "integrity": "sha512-TKJKz1fqBOZBaIQ/MGRKU0EnTGmKMLy4ReTRgP10AgtfOWBbj9PBg4MgY80GFpqGbs2EzcIctW5gbwbP4woDYg==",
       "requires": {
         "minipass": "2.2.1",
-        "minizlib": "1.0.4",
+        "minizlib": "1.1.0",
         "mkdirp": "0.5.1",
         "yallist": "3.0.2"
       },
@@ -4106,9 +4119,9 @@
       }
     },
     "ws": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.2.tgz",
-      "integrity": "sha512-t+WGpsNxhMR4v6EClXS8r8km5ZljKJzyGhJf7goJz9k5Ye3+b5Bvno5rjqPuIBn5mnn5GBb7o8IrIWHxX1qOLQ==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
+      "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
       "requires": {
         "async-limiter": "1.0.0",
         "safe-buffer": "5.1.1",

--- a/src/Hangashore/package.json
+++ b/src/Hangashore/package.json
@@ -16,7 +16,7 @@
     "@cycle/rxjs-run": "7.0.0",
     "@lakemaps/schemas": "3.4.18",
     "hypercycle": "6.0.0",
-    "openlayers": "4.5.0",
+    "openlayers": "4.6.4",
     "rxjs": "5.4.2",
     "tachyons": "4.7.4",
     "xstream": "10.8.0"


### PR DESCRIPTION
This PR fixes the potential security vulnerability that exists in version range `< 0.3.9` of `marked`, a sub-dependency of OpenLayers.